### PR TITLE
fix build broken since release of LTS 7.9 and drop GCP account in Europe

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,7 +71,7 @@ postgresql106_task:
           POSTGRES_PASSWORD: postgres
   env:
     matrix:
-      SQ_RUNTIME: LATEST_RELEASE
+      SQ_RUNTIME: 7.8
       SQ_RUNTIME: 6.7.7
   gradle_cache:
     folder: ~/.gradle/caches
@@ -114,7 +114,7 @@ oracle12_task:
           ORACLE_PWD: sonarqube
   env:
     matrix:
-      SQ_RUNTIME: LATEST_RELEASE
+      SQ_RUNTIME: 7.8
       SQ_RUNTIME: 6.7.7
   gradle_cache:
     folder: ~/.gradle/caches
@@ -159,7 +159,7 @@ mssql2017_task:
           SA_PASSWORD: sonarqube!1
   env:
     matrix:
-      SQ_RUNTIME: LATEST_RELEASE
+      SQ_RUNTIME: 7.8
       SQ_RUNTIME: 6.7.7
   gradle_cache:
     folder: ~/.gradle/caches

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,8 +24,8 @@ build_task:
     dockerfile: docker/Dockerfile-build
     builder_image_project: ci-cd-215716
     builder_image_name: docker-builder-v1
-    cluster_name: cirrus-euw3a-cluster
-    zone: europe-west3-a
+    cluster_name: cirrus-uscentral1a-cluster
+    zone: us-central1-a
     namespace: default
     cpu: 3
     memory: 10Gb
@@ -45,8 +45,8 @@ postgresql106_task:
     dockerfile: docker/Dockerfile-build
     builder_image_project: ci-cd-215716
     builder_image_name: docker-builder-v1
-    cluster_name: cirrus-euw3a-cluster
-    zone: europe-west3-a
+    cluster_name: cirrus-uscentral1a-cluster
+    zone: us-central1-a
     namespace: default
     cpu: 1
     memory: 10Gb
@@ -89,8 +89,8 @@ oracle12_task:
     dockerfile: docker/Dockerfile-build
     builder_image_project: ci-cd-215716
     builder_image_name: docker-builder-v1
-    cluster_name: cirrus-euw3a-cluster
-    zone: europe-west3-a
+    cluster_name: cirrus-uscentral1a-cluster
+    zone: us-central1-a
     namespace: default
     cpu: 1
     memory: 3Gb
@@ -132,8 +132,8 @@ mssql2017_task:
     dockerfile: docker/Dockerfile-build
     builder_image_project: ci-cd-215716
     builder_image_name: docker-builder-v1
-    cluster_name: cirrus-euw3a-cluster
-    zone: europe-west3-a
+    cluster_name: cirrus-uscentral1a-cluster
+    zone: us-central1-a
     namespace: default
     cpu: 1
     memory: 3Gb
@@ -181,8 +181,8 @@ promote_task:
     dockerfile: docker/Dockerfile-build
     builder_image_project: ci-cd-215716
     builder_image_name: docker-builder-v1
-    cluster_name: cirrus-euw3a-cluster
-    zone: europe-west3-a
+    cluster_name: cirrus-uscentral1a-cluster
+    zone: us-central1-a
     namespace: default
     cpu: 1
     memory: 1Gb

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,7 @@ postgresql106_task:
     zone: us-central1-a
     namespace: default
     cpu: 1
-    memory: 10Gb
+    memory: 3Gb
     additional_containers:
       - name: mysql
         image: mysql:5.7 # see https://github.com/mysql/mysql-docker


### PR DESCRIPTION
IT were testing the tool against LATEST_RELEASE version of SQ

Before release of LTS, this worked fine. But when LATEST_RELEASE became LTS 7.9.1, the ITs broke because 7.9.1 does not support MySQL at all: starting the "source" SQ instance to initialize a MySQL database fails.

Also, as 7.9.1 can not start on MySQL, the tool itself can't be used since the tools only works migrating version X to version X.

Therefor, it makes sense to only test the tool against 7.8 and not LTS.